### PR TITLE
Adjust API key flow and add reset control

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -212,7 +212,13 @@ const App: React.FC = () => {
         return <ErrorView error={processingError || '알 수 없는 오류가 발생했습니다.'} onReset={handleReset} />;
       case 'idle':
       default:
-        return <FileUpload onFilesSelect={handleFilesSelect} setProcessingError={handleSetError} />;
+        return (
+          <FileUpload
+            onFilesSelect={handleFilesSelect}
+            setProcessingError={handleSetError}
+            onResetCredentials={handleClearCredentials}
+          />
+        );
     }
   };
 

--- a/components/ApiKeySetup.tsx
+++ b/components/ApiKeySetup.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { GeminiModel } from '../types';
 
 interface ApiKeySetupProps {
@@ -39,34 +39,16 @@ const ApiKeySetup: React.FC<ApiKeySetupProps> = ({
   const [selectedModel, setSelectedModel] = useState<GeminiModel>(initialModel);
   const [error, setError] = useState<string | null>(null);
   const [isVerifying, setIsVerifying] = useState(false);
-  const hasHandledInitialFlash = useRef(false);
 
   useEffect(() => {
-    if (hasHandledInitialFlash.current) {
-      return;
+    if (initialModel === 'gemini-2.5-flash' && !defaultFlashApiKey) {
+      setError('기본 Flash API 키가 설정되어 있지 않습니다. .env.local 파일에서 GEMINI_API_KEY를 설정해주세요.');
     }
-
-    if (initialModel !== 'gemini-2.5-flash') {
-      hasHandledInitialFlash.current = true;
-      return;
-    }
-
-    hasHandledInitialFlash.current = true;
-
-    if (!defaultFlashApiKey) {
-      setError(
-        '기본 Flash API 키가 설정되어 있지 않습니다. .env.local 파일에서 GEMINI_API_KEY를 설정해주세요.'
-      );
-      return;
-    }
-
-    onSubmit(defaultFlashApiKey, 'gemini-2.5-flash');
-  }, [defaultFlashApiKey, initialModel, onSubmit]);
+  }, [defaultFlashApiKey, initialModel]);
 
   const handleModelSelect = (model: GeminiModel) => {
     setSelectedModel(model);
     setApiKey('');
-    setError(null);
 
     if (model === 'gemini-2.5-flash') {
       if (!defaultFlashApiKey) {
@@ -74,8 +56,21 @@ const ApiKeySetup: React.FC<ApiKeySetupProps> = ({
         return;
       }
 
-      onSubmit(defaultFlashApiKey, model);
+      setError(null);
+      onSubmit(defaultFlashApiKey, 'gemini-2.5-flash');
+      return;
     }
+
+    setError(null);
+  };
+
+  const handleFlashContinue = () => {
+    if (!defaultFlashApiKey) {
+      setError('기본 Flash API 키가 설정되어 있지 않습니다. .env.local 파일에서 GEMINI_API_KEY를 설정해주세요.');
+      return;
+    }
+
+    onSubmit(defaultFlashApiKey, 'gemini-2.5-flash');
   };
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -174,8 +169,18 @@ const ApiKeySetup: React.FC<ApiKeySetupProps> = ({
         </form>
       )}
 
-      {selectedModel === 'gemini-2.5-flash' && error && (
-        <p className="mt-4 text-sm text-red-600">{error}</p>
+      {selectedModel === 'gemini-2.5-flash' && (
+        <div className="mt-6 space-y-4">
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <button
+            type="button"
+            onClick={handleFlashContinue}
+            className="w-full py-2.5 text-sm font-semibold text-white bg-sky-600 rounded-lg hover:bg-sky-500 transition-colors disabled:opacity-70 disabled:cursor-not-allowed"
+            disabled={isVerifying}
+          >
+            Flash 기본 키로 계속
+          </button>
+        </div>
       )}
     </div>
   );

--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -4,6 +4,7 @@ import { UploadCloudIcon, SparklesIcon, DocumentTextIcon, CheckIcon } from './ic
 interface FileUploadProps {
   onFilesSelect: (files: File[]) => void;
   setProcessingError: (error: string) => void;
+  onResetCredentials?: () => void;
 }
 
 const LAW_FILES = [
@@ -86,7 +87,7 @@ const FileInput: React.FC<{
 };
 
 
-const FileUpload: React.FC<FileUploadProps> = ({ onFilesSelect, setProcessingError }) => {
+const FileUpload: React.FC<FileUploadProps> = ({ onFilesSelect, setProcessingError, onResetCredentials }) => {
   const [files, setFiles] = useState<(File | null)[]>(Array(LAW_FILES.length).fill(null));
 
   const handleFileChange = (file: File, index: number) => {
@@ -118,6 +119,17 @@ const FileUpload: React.FC<FileUploadProps> = ({ onFilesSelect, setProcessingErr
       </div>
       
       <div className="bg-white/80 p-6 rounded-2xl shadow-lg backdrop-blur-sm border border-slate-200/50">
+          {onResetCredentials && (
+            <div className="flex justify-end mb-4">
+              <button
+                type="button"
+                onClick={onResetCredentials}
+                className="text-sm font-semibold text-sky-600 hover:text-sky-500"
+              >
+                API 키 변경
+              </button>
+            </div>
+          )}
           <h2 className="text-lg font-semibold text-center text-slate-800 mb-2">2대 핵심 법령 업로드</h2>
           <p className="text-center text-sm text-slate-500 mb-6">정확한 분석을 위해 아래 2가지 법령 PDF 파일을 모두 업로드해주세요.</p>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">


### PR DESCRIPTION
## Summary
- stop auto-submitting the default Flash key on mount, surfacing missing-key warnings and adding an explicit continue control
- keep Flash selection advancing while introducing a manual "Flash 기본 키로 계속" button for re-submission
- expose an API 키 변경 action on the upload screen by threading the credential reset handler into the idle state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccf7ad441883289ef4f7ed9e8df390