### PR TITLE
Support Flash fallback and Pro upgrade via API keys

### DIFF
--- a/components/ApiKeySetup.tsx
+++ b/components/ApiKeySetup.tsx
@@ -1,28 +1,15 @@
 import React, { useState } from 'react';
 import { GoogleGenAI } from '@google/genai';
-import { GeminiModel } from '../types';
 
 interface ApiKeySetupProps {
-  onSubmit: (apiKey: string, model: GeminiModel) => void;
-  initialModel?: GeminiModel;
+  onSubmit: (apiKey: string) => void;
+  allowSkip?: boolean;
+  onSkip?: () => void;
+  onCancel?: () => void;
 }
 
-const modelOptions: { value: GeminiModel; label: string; description: string }[] = [
-  {
-    value: 'gemini-2.5-pro',
-    label: 'Gemini 2.5 Pro',
-    description: '최고 품질의 분석 결과가 필요한 경우에 적합합니다.'
-  },
-  {
-    value: 'gemini-2.5-flash',
-    label: 'Gemini 2.5 Flash',
-    description: '빠른 응답 속도가 필요한 경우에 적합합니다.'
-  }
-];
-
-const ApiKeySetup: React.FC<ApiKeySetupProps> = ({ onSubmit, initialModel = 'gemini-2.5-flash' }) => {
+const ApiKeySetup: React.FC<ApiKeySetupProps> = ({ onSubmit, allowSkip = false, onSkip, onCancel }) => {
   const [apiKey, setApiKey] = useState('');
-  const [selectedModel, setSelectedModel] = useState<GeminiModel>(initialModel);
   const [error, setError] = useState<string | null>(null);
   const [isValidating, setIsValidating] = useState(false);
 
@@ -42,7 +29,7 @@ const ApiKeySetup: React.FC<ApiKeySetupProps> = ({ onSubmit, initialModel = 'gem
       const client = new GoogleGenAI({ apiKey: trimmedKey });
       await client.models.list({ pageSize: 1 });
 
-      onSubmit(trimmedKey, selectedModel);
+      onSubmit(trimmedKey);
       setApiKey('');
     } catch (err) {
       const message =
@@ -59,8 +46,8 @@ const ApiKeySetup: React.FC<ApiKeySetupProps> = ({ onSubmit, initialModel = 'gem
     <div className="max-w-lg w-full bg-white shadow-xl rounded-2xl p-6 border border-slate-200">
       <h1 className="text-2xl font-bold text-slate-800 mb-4">Gemini API 설정</h1>
       <p className="text-sm text-slate-600 mb-6 leading-relaxed">
-        앱은 API 키를 저장하지 않습니다. Microsoft Store 보안 정책을 준수하기 위해 사용자가 직접 입력한 키만
-        즉시 호출에 사용하며, 페이지를 새로고침하면 키는 사라집니다.
+        앱은 API 키를 저장하지 않습니다. 사용자가 직접 입력한 키만 즉시 호출에 사용하며, 페이지를 새로고침하면 키는
+        사라집니다. 키를 입력하면 <strong>Gemini 2.5 Pro</strong> 모델이 활성화됩니다.
       </p>
       <form onSubmit={handleSubmit} className="space-y-5">
         <div>
@@ -81,42 +68,35 @@ const ApiKeySetup: React.FC<ApiKeySetupProps> = ({ onSubmit, initialModel = 'gem
           </p>
         </div>
 
-        <fieldset>
-          <legend className="block text-sm font-medium text-slate-700 mb-2">사용할 모델</legend>
-          <div className="space-y-3">
-            {modelOptions.map((option) => (
-              <label
-                key={option.value}
-                className={`flex items-start gap-3 p-3 border rounded-lg cursor-pointer transition-colors ${
-                  selectedModel === option.value ? 'border-sky-500 bg-sky-50/80' : 'border-slate-200 hover:border-sky-200'
-                }`}
-              >
-                <input
-                  type="radio"
-                  name="gemini-model"
-                  value={option.value}
-                  checked={selectedModel === option.value}
-                  onChange={() => setSelectedModel(option.value)}
-                  className="mt-1"
-                />
-                <div>
-                  <p className="text-sm font-semibold text-slate-800">{option.label}</p>
-                  <p className="text-xs text-slate-600 mt-1">{option.description}</p>
-                </div>
-              </label>
-            ))}
-          </div>
-        </fieldset>
-
         {error && <p className="text-sm text-red-600">{error}</p>}
 
-        <button
-          type="submit"
-          disabled={isValidating}
-          className="w-full py-2.5 text-sm font-semibold text-white bg-sky-600 rounded-lg hover:bg-sky-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {isValidating ? '검증 중...' : '저장하고 시작하기'}
-        </button>
+        <div className="space-y-3">
+          <button
+            type="submit"
+            disabled={isValidating}
+            className="w-full py-2.5 text-sm font-semibold text-white bg-sky-600 rounded-lg hover:bg-sky-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isValidating ? '검증 중...' : 'Pro 모델로 계속하기'}
+          </button>
+          {allowSkip && onSkip && (
+            <button
+              type="button"
+              onClick={onSkip}
+              className="w-full py-2.5 text-sm font-semibold text-slate-700 bg-slate-100 rounded-lg hover:bg-slate-200 transition-colors"
+            >
+              Flash 모델로 계속 사용하기
+            </button>
+          )}
+          {onCancel && (
+            <button
+              type="button"
+              onClick={onCancel}
+              className="w-full py-2.5 text-sm font-semibold text-slate-500 bg-white border border-slate-200 rounded-lg hover:bg-slate-50 transition-colors"
+            >
+              취소
+            </button>
+          )}
+        </div>
       </form>
     </div>
   );

--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -4,6 +4,8 @@ import { UploadCloudIcon, SparklesIcon, DocumentTextIcon, CheckIcon } from './ic
 interface FileUploadProps {
   onFilesSelect: (files: File[]) => void;
   setProcessingError: (error: string) => void;
+  onRequestApiKeySetup?: () => void;
+  isUsingUserApiKey?: boolean;
 }
 
 const LAW_FILES = [
@@ -86,7 +88,7 @@ const FileInput: React.FC<{
 };
 
 
-const FileUpload: React.FC<FileUploadProps> = ({ onFilesSelect, setProcessingError }) => {
+const FileUpload: React.FC<FileUploadProps> = ({ onFilesSelect, setProcessingError, onRequestApiKeySetup, isUsingUserApiKey = false }) => {
   const [files, setFiles] = useState<(File | null)[]>(Array(LAW_FILES.length).fill(null));
 
   const handleFileChange = (file: File, index: number) => {
@@ -117,6 +119,22 @@ const FileUpload: React.FC<FileUploadProps> = ({ onFilesSelect, setProcessingErr
         </p>
       </div>
       
+      <div className="flex justify-center mb-6">
+        <div className="flex flex-col sm:flex-row items-center gap-3 bg-white/80 border border-slate-200 rounded-xl px-5 py-3 shadow-sm">
+          <span className="text-sm text-slate-700">
+            현재 모델: <strong>{isUsingUserApiKey ? 'Gemini 2.5 Pro' : 'Gemini 2.5 Flash'}</strong>
+          </span>
+          {onRequestApiKeySetup && (
+            <button
+              onClick={onRequestApiKeySetup}
+              className="px-4 py-2 text-sm font-semibold text-sky-700 bg-sky-100 rounded-lg hover:bg-sky-200 transition-colors"
+            >
+              {isUsingUserApiKey ? 'API 키 변경' : 'API 키 입력하고 업그레이드'}
+            </button>
+          )}
+        </div>
+      </div>
+
       <div className="bg-white/80 p-6 rounded-2xl shadow-lg backdrop-blur-sm border border-slate-200/50">
           <h2 className="text-lg font-semibold text-center text-slate-800 mb-2">2대 핵심 법령 업로드</h2>
           <p className="text-center text-sm text-slate-500 mb-6">정확한 분석을 위해 아래 2가지 법령 PDF 파일을 모두 업로드해주세요.</p>

--- a/components/SearchView.tsx
+++ b/components/SearchView.tsx
@@ -392,10 +392,11 @@ interface SearchViewProps {
   apiKey: string;
   model: GeminiModel;
   onChangeModel: (model: GeminiModel) => void;
-  onResetCredentials: () => void;
+  onRequestApiKeySetup: () => void;
+  isUsingUserApiKey: boolean;
 }
 
-const SearchView: React.FC<SearchViewProps> = ({ fileNames, chunks, formTemplates = {}, onReset, apiKey, model: selectedModel, onChangeModel, onResetCredentials }) => {
+const SearchView: React.FC<SearchViewProps> = ({ fileNames, chunks, formTemplates = {}, onReset, apiKey, model: selectedModel, onChangeModel, onRequestApiKeySetup, isUsingUserApiKey }) => {
   const [query, setQuery] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [result, setResult] = useState<AnalysisResult | null>(null);
@@ -626,15 +627,25 @@ const handleSearch = useCallback(async () => {
                 aria-label="Gemini 모델 선택"
               >
                 {MODEL_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>{option.label}</option>
+                  <option
+                    key={option.value}
+                    value={option.value}
+                    disabled={!isUsingUserApiKey && option.value !== 'gemini-2.5-flash'}
+                  >
+                    {option.label}
+                    {!isUsingUserApiKey && option.value !== 'gemini-2.5-flash' ? ' (API 키 필요)' : ''}
+                  </option>
                 ))}
               </select>
             </div>
+            {!isUsingUserApiKey && (
+              <span className="text-xs text-slate-500">Pro 모델은 API 키 입력 후 사용 가능합니다.</span>
+            )}
             <button
-              onClick={onResetCredentials}
+              onClick={onRequestApiKeySetup}
               className="px-3 py-1.5 text-sm font-semibold text-slate-600 bg-white border border-slate-300 rounded-md hover:bg-slate-50"
             >
-              API 키 재설정
+              {isUsingUserApiKey ? 'API 키 변경' : 'API 키 입력'}
             </button>
             <button onClick={() => setIsHistoryVisible(!isHistoryVisible)} className="p-2 rounded-md text-slate-500 hover:bg-slate-200 hover:text-slate-800 transition-colors">
                 <HistoryIcon className="w-5 h-5"/>


### PR DESCRIPTION
## Summary
- add environment-driven fallback API key handling with guards so Flash mode works without user input
- refresh the API key setup flow and surfacing so users can upgrade to Pro or continue in Flash mode as needed
- update upload and search views to reflect the active model and restrict Pro-only controls when no personal key is present

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd0a5187548328add90c11c65ee251