### PR TITLE
Expose non-VITE env vars to import.meta

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -112,14 +112,6 @@ const readEnvValue = (key: string): string | null => {
   } catch (error) {
     // import.meta.env is only available in the browser build; ignore reference errors during SSR.
   }
-
-  if (typeof process !== 'undefined' && process.env) {
-    const value = process.env[key];
-    if (typeof value === 'string' && value.trim().length > 0) {
-      return value.trim();
-    }
-  }
-
   return null;
 };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,9 +4,16 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
+    const importMetaEnvEntries = Object.entries(env).reduce<Record<string, string>>((acc, [key, value]) => {
+      if (!key.startsWith('VITE_')) {
+        acc[`import.meta.env.${key}`] = JSON.stringify(value);
+      }
+      return acc;
+    }, {});
     return {
       plugins: [react()],
       define: {
+        ...importMetaEnvEntries,
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
       },


### PR DESCRIPTION
## Summary
- populate `import.meta.env` definitions for non-VITE variables in the Vite config so Gemini keys reach the browser bundle
- simplify the environment reader in `App.tsx` to rely solely on the Vite-provided `import.meta.env` values for the packaged fallback key

## Testing
- `npm install --ignore-scripts`
- `GEMINI_FLASH_API_KEY=demo GEMINI_API_KEY=demo API_KEY=demo npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cd912b06a88328804785a2c9191257